### PR TITLE
fix #28: add support for linux compilation

### DIFF
--- a/palette/src/ida/plugin.h
+++ b/palette/src/ida/plugin.h
@@ -19,6 +19,7 @@
 
 #define __DEFINE_PLUGIN_RETURN_CODES__
 
+#include <cstdint>
 #include <pro.h>
 #include <ida.hpp>
 #include <idp.hpp>


### PR DESCRIPTION
This fixes the issue at #28 

I have used this bash script to compile on linux. (BTW; Arch GNU/Linux)

```
#!/bin/sh

export IDA_SDK="/opt/idapro82/sdk"
export IDA_INSTALL_DIR="/opt/idapro82"

cmake ../ \
    -DIDA_SDK="$IDA_SDK" \
    -DIDA_BINARY_64=True \
    -DIDA_EA_64=False \
    -GNinja \
    -DPYBIND11_PYTHON_VERSION=3 \
    -DIDA_INSTALL_DIR="$IDA_INSTALL_DIR"
```

For 64-bit IDA change `-DIDA_EA_64=False \` to `-DIDA_EA_64=True \`