### PR TITLE
up: Qt6 tweaks

### DIFF
--- a/palette/CMakeLists.txt
+++ b/palette/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.21)
 
 include("ida-cmake/cmake/QtIDA.cmake")
 include("ida-cmake/cmake/IDA.cmake")
@@ -36,7 +36,7 @@ set(sources src/search_services/basic_service.cpp
         )
 
 add_library(palette STATIC ${sources})
-target_link_libraries(palette PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets ${python_libraries})
+target_link_libraries(palette PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets ${python_libraries})
 target_compile_definitions(palette PUBLIC "QT_NAMESPACE=QT" ${python_support_definitions})
 
 target_include_directories(palette
@@ -52,3 +52,6 @@ GENERATE_EXPORT_HEADER(palette)
 
 # IDA plugins
 add_subdirectory(src/ida)
+
+# Compile with fPIC
+set_target_properties(palette PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/palette/src/ida/CMakeLists.txt
+++ b/palette/src/ida/CMakeLists.txt
@@ -21,4 +21,4 @@ if ((${PYTHON_SUPPORT}) AND (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
 endif ()
 
 target_link_libraries(ida_palette
-        PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets palette ${python_libraries})
+        PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets palette ${python_libraries})

--- a/palette/src/ida/plugin.cpp
+++ b/palette/src/ida/plugin.cpp
@@ -211,11 +211,11 @@ class NamesManager {
     for (auto& action : *names) {
       auto sep = action.id.indexOf(':');
       if (action.id.startsWith("struct:")) {
-        address_to_struct.insert(action.id.midRef(sep + 1).toULongLong(nullptr),
+        address_to_struct.insert(QStringView(action.id).mid(sep + 1).toULongLong(nullptr),
                                  index);
       } else {
         address_to_name.insert(
-            action.id.midRef(0, sep).toULongLong(nullptr, 16), index);
+            QStringView(action.id).mid(0, sep).toULongLong(nullptr, 16), index);
       }
       index++;
     }
@@ -419,7 +419,7 @@ class name_palette_handler : public action_handler_t {
         [](Action& action) {
           auto&& id = action.id;
           if (id.startsWith("struct:")) {
-            auto tid = id.midRef(7).toULongLong();
+            auto tid = QStringView(id).mid(7).toULongLong();
             jump_to_type(tid);
           } else {
             ea_t address = static_cast<ea_t>(id.toULongLong(nullptr, 16));

--- a/palette/src/ida/plugin.h
+++ b/palette/src/ida/plugin.h
@@ -1,5 +1,9 @@
 #pragma warning(push)
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #if _MSC_VER
 // Visual Studio
 #pragma warning(disable : 4244)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.21)
 
 project(standalone)
 
@@ -6,7 +6,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 # Locate Qt.
-find_package(Qt5Widgets CONFIG REQUIRED)
+find_package(Qt6Widgets CONFIG REQUIRED)
 
 add_executable(standalone standalone.cpp)
-target_link_libraries(standalone Qt5::Widgets palette)
+target_link_libraries(standalone Qt6::Widgets palette)


### PR DESCRIPTION
Hex-rays devs migrated to Qt6. This project is for Qt5.

## Changes

* Simple Changed `Qt5` prefixes to `Qt6`
* Qt6 gave error on QString, It wants QStringView.  So I have changed `id.midRef` to `QStringView(id).mid`

My intention was to make the smallest change!

**IMPORTANT**: As I have mentioned in this issue, I have successfully built this plugin on Linux x86_64 platform. I got errors on mac an win systems but I think they are because of the falsy building environment of mine. It is easy to establish a Qt6 building environment on Linux you know.